### PR TITLE
ax concordances, placetype local, and more

### DIFF
--- a/data/856/678/35/85667835.geojson
+++ b/data/856/678/35/85667835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0164,
-    "geom:area_square_m":100645345.440319,
+    "geom:area_square_m":100645234.312492,
     "geom:bbox":"19.81422,60.170408,20.030528,60.370185",
     "geom:latitude":60.243497,
     "geom:longitude":19.920468,
@@ -291,8 +291,9 @@
         "wd:id":"Q51914",
         "wk:page":"Finstr\u00f6m"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"6c2eb6985a46c4eeef39d2224bff4cb6",
+    "wof:geomhash":"1c1763350700a57222dc485c720dcfa9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +310,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855710,
+    "wof:lastmodified":1695884324,
     "wof:name":"Finstr\u00f6m",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/43/85667843.geojson
+++ b/data/856/678/43/85667843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019613,
-    "geom:area_square_m":120774355.341962,
+    "geom:area_square_m":120774519.813474,
     "geom:bbox":"19.747569,60.07392,20.050466,60.186225",
     "geom:latitude":60.131667,
     "geom:longitude":19.911966,
@@ -306,8 +306,9 @@
         "wd:id":"Q176178",
         "wk:page":"Jomala"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"25b2cd9da33bd883f1cd1a6700ab0e4b",
+    "wof:geomhash":"2786744e39d9cf3cbef5218703dddc10",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -324,7 +325,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855712,
+    "wof:lastmodified":1695884795,
     "wof:name":"Jomala",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/45/85667845.geojson
+++ b/data/856/678/45/85667845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018608,
-    "geom:area_square_m":114344356.374115,
+    "geom:area_square_m":114344413.594015,
     "geom:bbox":"19.646983,60.101386,19.833108,60.380154",
     "geom:latitude":60.201912,
     "geom:longitude":19.744588,
@@ -288,8 +288,9 @@
         "wd:id":"Q134685",
         "wk:page":"Hammarland"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"880ac5bfb127b8767633caf10a2d733b",
+    "wof:geomhash":"a2a477fe6d150bb5c2e007b422b4120b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -306,7 +307,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855711,
+    "wof:lastmodified":1695884325,
     "wof:name":"Hammarland",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/49/85667849.geojson
+++ b/data/856/678/49/85667849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0147,
-    "geom:area_square_m":90316164.289819,
+    "geom:area_square_m":90315897.686214,
     "geom:bbox":"19.326264,60.12995,19.674327,60.36636",
     "geom:latitude":60.207138,
     "geom:longitude":19.57946,
@@ -301,8 +301,9 @@
         "wd:id":"Q51909",
         "wk:page":"Ecker\u00f6"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"ab1944168d8b8277f67b4cdbd2dd81df",
+    "wof:geomhash":"94c6c4cf49cc49749ce82082297797df",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -319,7 +320,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855714,
+    "wof:lastmodified":1695884325,
     "wof:name":"Ecker\u00f6",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/53/85667853.geojson
+++ b/data/856/678/53/85667853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007794,
-    "geom:area_square_m":47648727.532769,
+    "geom:area_square_m":47648573.570201,
     "geom:bbox":"19.705007,60.313218,19.918468,60.405585",
     "geom:latitude":60.36871,
     "geom:longitude":19.847055,
@@ -285,8 +285,9 @@
         "wd:id":"Q134675",
         "wk:page":"Geta, \u00c5land"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"c572d591f3a352c53fb66ced068f6881",
+    "wof:geomhash":"f5da63ed6014296e1ab19df08b5b93a0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -303,7 +304,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855712,
+    "wof:lastmodified":1695884325,
     "wof:name":"Geta",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/57/85667857.geojson
+++ b/data/856/678/57/85667857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013874,
-    "geom:area_square_m":85709134.252506,
+    "geom:area_square_m":85709041.732257,
     "geom:bbox":"20.281315,59.953624,20.617931,60.11286",
     "geom:latitude":60.026648,
     "geom:longitude":20.448856,
@@ -280,8 +280,9 @@
         "wd:id":"Q179722",
         "wk:page":"F\u00f6gl\u00f6"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"8ed1c2a8af95e2741e3964dccf71ccab",
+    "wof:geomhash":"d8c36daccc605f6966b068177db55285",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -298,7 +299,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855710,
+    "wof:lastmodified":1695884324,
     "wof:name":"F\u00f6gl\u00f6",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/63/85667863.geojson
+++ b/data/856/678/63/85667863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015862,
-    "geom:area_square_m":97140543.432855,
+    "geom:area_square_m":97140508.029951,
     "geom:bbox":"19.948469,60.226508,20.164818,60.404568",
     "geom:latitude":60.312197,
     "geom:longitude":20.0463,
@@ -282,8 +282,9 @@
         "wd:id":"Q176196",
         "wk:page":"Saltvik"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"42c9942d2ed5237a604d419acb03853b",
+    "wof:geomhash":"f3123206f1d8fdf16d0d3adf3a8cfc78",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -300,7 +301,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855713,
+    "wof:lastmodified":1695884325,
     "wof:name":"Saltvik",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/67/85667867.geojson
+++ b/data/856/678/67/85667867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01724,
-    "geom:area_square_m":105811296.053365,
+    "geom:area_square_m":105811296.053348,
     "geom:bbox":"20.0481876957,60.1671410183,20.2775985039,60.3257780045",
     "geom:latitude":60.241275,
     "geom:longitude":20.157402,
@@ -202,8 +202,9 @@
         "hasc:id":"AX.SD",
         "qs_pg:id":427798
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"1f24c49ba3a1c23919547eb77465a69e",
+    "wof:geomhash":"5370c8c2e362e13c13c8112520244bf6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -220,7 +221,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1566603653,
+    "wof:lastmodified":1695884325,
     "wof:name":"Sund",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/71/85667871.geojson
+++ b/data/856/678/71/85667871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001387,
-    "geom:area_square_m":8554690.534145,
+    "geom:area_square_m":8554690.534147,
     "geom:bbox":"19.91033,60.047675,19.965994,60.110769",
     "geom:latitude":60.083527,
     "geom:longitude":19.94037,
@@ -369,11 +369,12 @@
         "hasc:id":"AX.MH",
         "qs_pg:id":1116990
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         101815223
     ],
     "wof:country":"AX",
-    "wof:geomhash":"8dfd1cf482c4724a496046c57207fcf1",
+    "wof:geomhash":"ae94a4de022357862870e86fa5c75b4c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -390,7 +391,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1636495470,
+    "wof:lastmodified":1695884795,
     "wof:name":"Mariehamn",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/75/85667875.geojson
+++ b/data/856/678/75/85667875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013382,
-    "geom:area_square_m":82638726.794728,
+    "geom:area_square_m":82638635.839094,
     "geom:bbox":"19.915294,59.835069,20.225218,60.094975",
     "geom:latitude":60.038491,
     "geom:longitude":20.130031,
@@ -294,8 +294,9 @@
         "wd:id":"Q176186",
         "wk:page":"Lemland"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"350b8a97de90d2f62a1e09bec3723f3b",
+    "wof:geomhash":"dd9bbe6dee3ef9e50c6074fb484714b2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +313,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855711,
+    "wof:lastmodified":1695884795,
     "wof:name":"Lemland",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/81/85667881.geojson
+++ b/data/856/678/81/85667881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004865,
-    "geom:area_square_m":29979751.581734,
+    "geom:area_square_m":29979947.438323,
     "geom:bbox":"20.198253,60.060492,20.297618,60.149604",
     "geom:latitude":60.105736,
     "geom:longitude":20.246129,
@@ -291,8 +291,9 @@
         "wd:id":"Q176191",
         "wk:page":"Lumparland"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"dd322a0bfd566bf7d260b07bf83c8a7a",
+    "wof:geomhash":"b2ef13539444b2588eddf61acef001e9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +310,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855712,
+    "wof:lastmodified":1695884795,
     "wof:name":"Lumparland",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/85/85667885.geojson
+++ b/data/856/678/85/85667885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009739,
-    "geom:area_square_m":59750011.561516,
+    "geom:area_square_m":59749896.721263,
     "geom:bbox":"20.252533,60.147447,20.516449,60.432807",
     "geom:latitude":60.256293,
     "geom:longitude":20.371424,
@@ -316,8 +316,9 @@
         "wd:id":"Q179749",
         "wk:page":"V\u00e5rd\u00f6"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"69aeb7ad33a434c644b0a2e0856e0fe9",
+    "wof:geomhash":"f4e24a2ed6b933c5b5183f1417fc5841",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -334,7 +335,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855713,
+    "wof:lastmodified":1695884325,
     "wof:name":"V\u00e5rd\u00f6",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/89/85667889.geojson
+++ b/data/856/678/89/85667889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002223,
-    "geom:area_square_m":13690602.657986,
+    "geom:area_square_m":13690693.613442,
     "geom:bbox":"20.566905,60.062486,20.823334,60.169664",
     "geom:latitude":60.123325,
     "geom:longitude":20.675422,
@@ -297,8 +297,9 @@
         "wd:id":"Q179739",
         "wk:page":"Sottunga"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"5c7e05b5d23ae1d9b8c262e8003d2f6f",
+    "wof:geomhash":"b3c22b0775b00b82b3cd5871f5c36acc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +316,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855711,
+    "wof:lastmodified":1695884795,
     "wof:name":"Sottunga",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/93/85667893.geojson
+++ b/data/856/678/93/85667893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008423,
-    "geom:area_square_m":51602057.676662,
+    "geom:area_square_m":51602085.806641,
     "geom:bbox":"20.600108,60.194566,20.936615,60.419135",
     "geom:latitude":60.302448,
     "geom:longitude":20.781834,
@@ -297,8 +297,9 @@
         "wd:id":"Q179726",
         "wk:page":"Kumlinge"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"1318d7360458c71509dcceb0d0662793",
+    "wof:geomhash":"5d2eebd999dd7b827f5505c5e4cc71f8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +316,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855711,
+    "wof:lastmodified":1695884795,
     "wof:name":"Kumlinge",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/678/99/85667899.geojson
+++ b/data/856/678/99/85667899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006691,
-    "geom:area_square_m":40822875.428285,
+    "geom:area_square_m":40822869.575667,
     "geom:bbox":"20.868663,60.215928,21.098562,60.558417",
     "geom:latitude":60.434246,
     "geom:longitude":21.020156,
@@ -292,8 +292,9 @@
         "wd:id":"Q179706",
         "wk:page":"Br\u00e4nd\u00f6"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"b9e66c7828d2cbb56e62a1b7f3f70e8d",
+    "wof:geomhash":"e066c803f3a9fb7e46b1826b41842723",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -310,7 +311,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855713,
+    "wof:lastmodified":1695884325,
     "wof:name":"Br\u00e4nd\u00f6",
     "wof:parent_id":85632789,
     "wof:placetype":"region",

--- a/data/856/679/03/85667903.geojson
+++ b/data/856/679/03/85667903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003163,
-    "geom:area_square_m":19591299.026715,
+    "geom:area_square_m":19591276.103893,
     "geom:bbox":"20.848318,59.904486,20.996593,60.025987",
     "geom:latitude":59.938071,
     "geom:longitude":20.924258,
@@ -288,8 +288,9 @@
         "qs_pg:id":1287353,
         "wd:id":"Q179730"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AX",
-    "wof:geomhash":"3933e82a0c6a9946c08ec56eaf2ebdb8",
+    "wof:geomhash":"79fcdc7ae1a4e1ac00ebb811e5646b05",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -306,7 +307,7 @@
     "wof:lang_x_spoken":[
         "swe"
     ],
-    "wof:lastmodified":1690855714,
+    "wof:lastmodified":1695884325,
     "wof:name":"K\u00f6kar",
     "wof:parent_id":85632789,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.